### PR TITLE
usage + executability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,15 @@
 
 Dungeons are from [WordNet](https://wordnet.princeton.edu/).
 Dragons are from [Kobold Fight Club](https://github.com/Asmor/5e-monsters).
+
+## Usage
+Install dependencies:
+
+```sh
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python -m nltk.downloader all
+```
+
+then run `./qnq.py` for more alliterations.

--- a/qnq.py
+++ b/qnq.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from collections import defaultdict
 import csv
 import json


### PR DESCRIPTION
didn't find a command to only download sampling, so currently rocking a 3.5G `nltk_data` dir unnecessarily